### PR TITLE
tool/down2ram.sh: parse missed '--config' option

### DIFF
--- a/tool/down2ram.sh
+++ b/tool/down2ram.sh
@@ -13,7 +13,7 @@ helpmsg()
     echo
 }
 
-ARGS=`getopt -a -o h -l bin:,downto:,runat:,help -- "$@"`
+ARGS=`getopt -a -o h -l config:,bin:,downto:,runat:,help -- "$@"`
 [ $? -ne 0 ] && helpmsg && exit
 #set -- "${ARGS}"
 eval set -- "${ARGS}"


### PR DESCRIPTION
Without this patch the down2ram.sh scripts can't parse the '--config'
option and exits with this error message

```
getopt: unrecognized option '--config=...'
```

Signed-off-by: Antony Pavlov antonynpavlov@gmail.com
